### PR TITLE
removed follow_redirect

### DIFF
--- a/lib/zuck/facebook/ad_creative.rb
+++ b/lib/zuck/facebook/ad_creative.rb
@@ -6,7 +6,6 @@ module Zuck
     known_keys :actor_id,
                :body,
                :call_to_action_type,
-               :follow_redirect,
                :image_crops,
                :image_file,
                :image_hash,

--- a/lib/zuck/facebook/ad_creative.rb
+++ b/lib/zuck/facebook/ad_creative.rb
@@ -7,7 +7,6 @@ module Zuck
                :body,
                :call_to_action_type,
                :image_crops,
-               :image_file,
                :image_hash,
                :image_url,
                :link_url,


### PR DESCRIPTION
`AdCreative.find(id)` fails with:

`type: OAuthException, code: 100, message: (#100) Tried accessing nonexisting field (follow_redirect) on node type (AdCreative) [HTTP 400] graph.get_object("6029285028392")
`

From: http://stackoverflow.com/questions/19161742/unknown-field-follow-redirect-while-fetching-facebook-ad-creatives-from-api

> There is no follow_redirect field on an adcreative, it's a flag you provide when creating the creative itself, but it isn't a property of the resulting creative